### PR TITLE
Merge upstream fix for array/slice support

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -99,19 +99,8 @@ func (enc *logfmtEncoder) AddInt64(key string, value int64) {
 }
 
 func (enc *logfmtEncoder) AddReflected(key string, value interface{}) error {
-	rvalue := reflect.ValueOf(value)
-	switch rvalue.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Map, reflect.Struct:
-		return ErrUnsupportedValueType
-	case reflect.Array, reflect.Slice, reflect.Ptr:
-		if rvalue.IsNil() {
-			enc.AddByteString(key, nil)
-			return nil
-		}
-		return enc.AddReflected(key, rvalue.Elem().Interface())
-	}
-	enc.AddString(key, fmt.Sprint(value))
-	return nil
+	enc.addKey(key)
+	return enc.AppendReflected(value)
 }
 
 func (enc *logfmtEncoder) OpenNamespace(key string) {
@@ -197,8 +186,26 @@ func (enc *logfmtEncoder) AppendInt64(value int64) {
 func (enc *logfmtEncoder) AppendReflected(value interface{}) error {
 	rvalue := reflect.ValueOf(value)
 	switch rvalue.Kind() {
-	case reflect.Array, reflect.Chan, reflect.Func, reflect.Map, reflect.Slice, reflect.Struct:
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Struct:
 		return ErrUnsupportedValueType
+	case reflect.Slice:
+		if rvalue.IsNil() {
+			enc.AppendByteString(nil)
+			return nil
+		}
+		// A non-nil slice is handled identically to an array.
+		fallthrough
+	case reflect.Array:
+		marshal := zapcore.ArrayMarshalerFunc(func(aenc zapcore.ArrayEncoder) error {
+			for i := 0; i < rvalue.Len(); i++ {
+				v := rvalue.Index(i).Interface()
+				if err := aenc.AppendReflected(v); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		return enc.AppendArray(marshal)
 	case reflect.Ptr:
 		if rvalue.IsNil() {
 			enc.AppendByteString(nil)
@@ -519,7 +526,35 @@ func (enc *literalEncoder) AppendObject(zapcore.ObjectMarshaler) error {
 }
 
 func (enc *literalEncoder) AppendReflected(value interface{}) error {
-	return ErrUnsupportedValueType
+	rvalue := reflect.ValueOf(value)
+	switch rvalue.Kind() {
+	case reflect.Bool:
+		enc.AppendBool(value.(bool))
+		return nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		enc.AppendInt64(rvalue.Int())
+		return nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		enc.AppendUint64(rvalue.Uint())
+		return nil
+	case reflect.Float32:
+		enc.AppendFloat32(value.(float32))
+		return nil
+	case reflect.Float64:
+		enc.AppendFloat64(value.(float64))
+		return nil
+	case reflect.Complex64:
+		enc.AppendComplex64(value.(complex64))
+		return nil
+	case reflect.Complex128:
+		enc.AppendComplex128(value.(complex128))
+		return nil
+	case reflect.String:
+		enc.AppendString(value.(string))
+		return nil
+	default:
+		return ErrUnsupportedValueType
+	}
 }
 
 func (enc *literalEncoder) addSeparator() {

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -84,6 +84,9 @@ func TestEncoderObjectFields(t *testing.T) {
 				e.OpenNamespace("innermost")
 			},
 		},
+		{"reflected slice", "k=a,b", func(e zapcore.Encoder) { e.AddReflected("k", []string{"a", "b"}) }},
+		{"reflected slice of int", "k=1,2,3", func(e zapcore.Encoder) { e.AddReflected("k", []int16{1, 2, 3}) }},
+		{"reflected array", "k=a,b", func(e zapcore.Encoder) { e.AddReflected("k", [2]string{"a", "b"}) }},
 	}
 
 	for _, tt := range tests {

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,16 @@
 module github.com/jsternberg/zap-logfmt
 
+go 1.17
+
+require (
+	github.com/stretchr/testify v1.2.2
+	go.uber.org/zap v1.9.1
+)
+
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
-	go.uber.org/zap v1.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,8 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=


### PR DESCRIPTION
Upstream fixed issue where zap-logfmt would panic when attempting to log an array/slice value